### PR TITLE
fix(*): return an empty list if the list of query objects is empty

### DIFF
--- a/appchain-mgr/appchain_mgr.go
+++ b/appchain-mgr/appchain_mgr.go
@@ -242,18 +242,16 @@ func (am *AppchainManager) CountAll(_ []byte) (bool, []byte) {
 
 // Appchains returns all appchains
 func (am *AppchainManager) All(_ []byte) (interface{}, error) {
-	ok, value := am.Query(PREFIX)
-	if !ok {
-		return nil, nil
-	}
-
 	ret := make([]*Appchain, 0)
-	for _, data := range value {
-		chain := &Appchain{}
-		if err := json.Unmarshal(data, chain); err != nil {
-			return nil, err
+	ok, value := am.Query(PREFIX)
+	if ok {
+		for _, data := range value {
+			chain := &Appchain{}
+			if err := json.Unmarshal(data, chain); err != nil {
+				return nil, err
+			}
+			ret = append(ret, chain)
 		}
-		ret = append(ret, chain)
 	}
 
 	return ret, nil

--- a/node-mgr/node_mgr.go
+++ b/node-mgr/node_mgr.go
@@ -178,18 +178,16 @@ func (nm *NodeManager) CountAll(nodeType []byte) (bool, []byte) {
 
 // All returns all nodes
 func (nm *NodeManager) All(_ []byte) (interface{}, error) {
-	ok, value := nm.Query(NODEPREFIX)
-	if !ok {
-		return nil, nil
-	}
-
 	ret := make([]*Node, 0)
-	for _, data := range value {
-		node := &Node{}
-		if err := json.Unmarshal(data, node); err != nil {
-			return nil, err
+	ok, value := nm.Query(NODEPREFIX)
+	if ok {
+		for _, data := range value {
+			node := &Node{}
+			if err := json.Unmarshal(data, node); err != nil {
+				return nil, err
+			}
+			ret = append(ret, node)
 		}
-		ret = append(ret, node)
 	}
 
 	return ret, nil

--- a/rule-mgr/rule_mgr.go
+++ b/rule-mgr/rule_mgr.go
@@ -87,12 +87,19 @@ func (rule *Rule) setFSM(lastStatus governance.GovernanceStatus) {
 		fsm.Callbacks{
 			"enter_state": func(e *fsm.Event) {
 				rule.Status = governance.GovernanceStatus(rule.FSM.Current())
+
+				// After the status change, if the rule is bound or the master authentication rule is updated successfully,
+				// we need to enable the master identifier of the master rule
 				if e.Event == string(governance.EventApprove) {
 					if rule.Status == governance.GovernanceAvailable {
 						rule.Master = true
 					} else {
 						rule.Master = false
 					}
+				}
+
+				if e.Event == string(governance.EventBind) {
+					rule.Master = true
 				}
 			},
 		},
@@ -220,10 +227,7 @@ func (rm *RuleManager) CountAll(chainID []byte) (bool, []byte) {
 // Appchains returns all appchains
 func (rm *RuleManager) All(chainID []byte) (interface{}, error) {
 	ret := make([]*Rule, 0)
-	ok := rm.GetObject(RuleKey(string(chainID)), &ret)
-	if !ok {
-		return nil, nil
-	}
+	_ = rm.GetObject(RuleKey(string(chainID)), &ret)
 
 	return ret, nil
 }


### PR DESCRIPTION
1. Returns an empty list if the list of query objects is empty;
2. Fix a bug where the master flag was not opened after binding rules。